### PR TITLE
Adding sequencial flag for table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ custom:
       - name: my-db # required, your database name, do not use an existing database, will be dropped in deployement process
         output: s3://my-athena-output-bucket/ # required, your results bucket
         ddl: $(file(my-database.sql)} # optional, your DDL containing the CREATE DATABASE statement
-        sequential: true #optional (default: false), true if you want to create the tables sequentially in case of dependencies between tables and views
+        sequential: true #optional (default: false), true if you want to create tables sequentially in case of dependencies between tables and views
         tables: # list of yout tables
           - name: mytable # required, table name
             ddl: $(file(my-table.sql)} # required, DDL containing the CREATE TABLE
@@ -40,7 +40,6 @@ custom:
         output: s3://my-athena-output-bucket/ # required, your results bucket
         ddl: $(file(my-database.sql)} # optional, your DDL containing the CREATE DATABASE statement
         enabled: false #optional (default: true), plugin will ignore this database creation
-        removeDatabase: false #optional (default: true), if this flag is set to false the plugin will first save the partitions and them delete and recreate the database
         tables: # list of yout tables
           - name: mytable # required, table name
             ddl: $(file(my-table.sql)} # required, DDL containing the CREATE TABLE

--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ function getExecutor({
         case 'SUCCEEDED':
           return Promise.resolve();
         case 'FAILED':
+          console.log(`FAILED QUERY ID ${QueryExecutionId} with params ${JSON.stringify(params)}`)
+          console.log(`RES: ${res}`)
           throw new Error('Query failed');
         case 'CANCELLED':
           throw new Error('Query as been cancelled');


### PR DESCRIPTION
Adding a flag to create tables sequentially. This flag resolves error while deploying a view that has dependencies with other tables that are being created as well

Also adding a flag to enable the creation of a database, is helpful when you just want to create your database in a production environment